### PR TITLE
Add trailing slash to data_frequency in build_prefix

### DIFF
--- a/binance_bulk_downloader/downloader.py
+++ b/binance_bulk_downloader/downloader.py
@@ -323,7 +323,7 @@ class BinanceBulkDownloader:
             and self._data_frequency
         ):
             if isinstance(self._symbols, (str, list)):
-                url_parts.append(self._data_frequency)
+                url_parts.append(f"{self._data_frequency}/")
 
         return "/".join(url_parts)
 


### PR DESCRIPTION
When requesting `1m` timeframe to download, it unintentionally requests `1mo` timeframe as well because `get_file_list_from_s3_bucket` function in downloader will compare key using their prefixes.

Adding a trailing slash in data_frequency in `build_prefix` function should help fixing the problem.